### PR TITLE
Adds support for COS

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,5 @@
 cloud.google.com/go v0.34.0 h1:eOI3/cP2VTU6uZLDYAoic+eyzzB9YyGmJ7eIjl8rOPg=
+
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 h1:w+iIsaOQNcT7OZ575w+acHgRric5iCyQh+xv+KJ4HB8=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=


### PR DESCRIPTION
* Loads /etc/ from host as a read only volume from probe loader can determine OS
* Enables the BPF Probe Loader via Environment Variable.

Both of these are necessary for sysdig to work on COS.

Tested against the following version of COS:

```
cat /etc/os-release

BUILD_ID=10895.138.0
NAME="Container-Optimized OS"
KERNEL_COMMIT_ID=edb81c460eee7a4a35e2a95ebf6450df0963398e
GOOGLE_CRASH_ID=Lakitu
VERSION_ID=69
BUG_REPORT_URL="https://cloud.google.com/container-optimized-os/docs/resources/support-policy#contact_us"
PRETTY_NAME="Container-Optimized OS from Google"
VERSION=69
GOOGLE_METRICS_PRODUCT_ID=26
HOME_URL="https://cloud.google.com/container-optimized-os/docs"
ID=cos

```